### PR TITLE
Make API URL a configurable build-time constant

### DIFF
--- a/src/Bird.js
+++ b/src/Bird.js
@@ -9,7 +9,7 @@ function Bird() {
 
   useEffect(() => {
     axios
-      .get("http://demo.jmunixusers.org:7777")
+      .get(process.env.BIRD_API_URL ?? "http://demo.jmunixusers.org:7777")
       .then((res) => {
         setData(res.data);
         console.log(res.data);


### PR DESCRIPTION
The URL for the API is currently hardcoded to a particular domain/port
combination. This will allow the app to talk to other backends by
settings a build-time environment variable `BIRDS_API_URL`. If that
value is not set at build-time, then the default will be used.
