### PR TITLE
Use fetch instead of axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
-        "axios": "^0.26.1",
         "bootstrap": "^5.1.3",
         "react": "^18.0.0",
         "react-bootstrap": "^2.2.3",
@@ -4524,14 +4523,6 @@
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/axobject-query": {
@@ -19345,14 +19336,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
-    },
-    "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "requires": {
-        "follow-redirects": "^1.14.8"
-      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
-    "axios": "^0.26.1",
     "bootstrap": "^5.1.3",
     "react": "^18.0.0",
     "react-bootstrap": "^2.2.3",

--- a/src/Bird.js
+++ b/src/Bird.js
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 
 import { Card } from 'react-bootstrap';
 
@@ -8,8 +7,7 @@ function Bird() {
   const [data, setData] = useState([])
 
   useEffect(() => {
-    axios
-      .get("http://demo.jmunixusers.org:7777")
+    fetch("http://demo.jmunixusers.org:7777")
       .then((res) => {
         setData(res.data);
         console.log(res.data);


### PR DESCRIPTION
This removes an additional dependency, leveraging browsers' buildin
`fetch` API, which has been supported basically everywhere for awhile
now (https://caniuse.com/fetch).
